### PR TITLE
Insert insigns table only when dataset is not created

### DIFF
--- a/install_scripts/03-ai-bubbles.sh
+++ b/install_scripts/03-ai-bubbles.sh
@@ -30,13 +30,13 @@ if bq --location=$DEFAULT_MULTI_REGION show --dataset dgpulse_ads_bq; then
 else
   # Create the dataset if it does not exist
   bq --location=$DEFAULT_MULTI_REGION mk -d dgpulse_ads_bq
-fi
 
-# Create the insights table
-bq mk \
-  -t \
-  dgpulse_ads_bq.insights \
-  table:STRING,insights:STRING,headline:STRING,date:DATE
+  # Create the insights table
+  bq mk \
+    -t \
+    dgpulse_ads_bq.insights \
+    table:STRING,insights:STRING,headline:STRING,date:DATE
+fi
 
 # step into ai_bubbles with sub project scripts.
 cd ai_bubbles


### PR DESCRIPTION
If you run script for second time (for update, or when first one fails) you get error similar to:

```
Dataset already exists.
BigQuery error in mk operation: Table 'GCP_PROJECT:dgpulse_ads_bq.insights' could not be created; a table with this name already exists.
```

Moved that to if will solve it. 