### PR TITLE
Bump Node version as v20 is being deprecated end of April

### DIFF
--- a/install_scripts/01-exchange-rates.sh
+++ b/install_scripts/01-exchange-rates.sh
@@ -48,7 +48,7 @@ echo "Deploying Run function for Exchange Rates"
 echo "Estimated time: Less than 5 minutes"
 gcloud functions deploy dgpulse-exchange-rates-fetcher \
   --gen2 \
-  --runtime=nodejs20 \
+  --runtime=nodejs22 \
   --region=$GCP_REGION \
   --source=. \
   --entry-point=exchangeRatesGET \

--- a/install_scripts/02-youtube-aspect-ratio.sh
+++ b/install_scripts/02-youtube-aspect-ratio.sh
@@ -54,7 +54,7 @@ echo "Deploying Run function for Youtube aspect ratio fetcher"
 echo "Estimated time: Less than 5 minutes"
 gcloud functions deploy dgpulse-youtube-aspect-ratio-fetcher \
   --gen2 \
-  --runtime=nodejs20 \
+  --runtime=nodejs22 \
   --region=$GCP_REGION \
   --source=. \
   --entry-point=ytarfGET \

--- a/install_scripts/03-ai-bubbles.sh
+++ b/install_scripts/03-ai-bubbles.sh
@@ -72,7 +72,7 @@ echo "Deploying Run function for AI Bubbles"
 echo "Estimated time: Less than 5 minutes"
 gcloud functions deploy dgpulse-ai-bubbles \
   --gen2 \
-  --runtime=nodejs20 \
+  --runtime=nodejs22 \
   --region=$GCP_REGION \
   --source=. \
   --entry-point=aiBubblesGET \


### PR DESCRIPTION
Upgrading node version to v22 on 3 installation scripts.
v20 is being deprecated at the end of April.
